### PR TITLE
Lift groovy version to 2.5.x to make it work with JDK14

### DIFF
--- a/tools/schema-tools/build.gradle
+++ b/tools/schema-tools/build.gradle
@@ -11,7 +11,7 @@ repositories {
 }
 
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.3.11'
+    compile 'org.codehaus.groovy:groovy-all:2.5.12'
     compile 'com.google.code.gson:gson:2.8.0'
     compile 'com.fasterxml.jackson.core:jackson-core:2.8.6'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.8.6'


### PR DESCRIPTION
Hi.

With `2.3.11` it won't build under Java 14 using `gradlew build`.

See also https://issues.apache.org/jira/browse/GROOVY-9211

An upgrade to `2.5.x` fixed it.